### PR TITLE
fix: use safe convert() instead of abi_decode/encode

### DIFF
--- a/contracts/oapp_vyper/OptionsBuilder.vy
+++ b/contracts/oapp_vyper/OptionsBuilder.vy
@@ -74,9 +74,7 @@ def addExecutorOption(
     assert (len(_options) + len(_option) <= MAX_OPTIONS_TOTAL_SIZE), "OApp: options size exceeded"
 
     return concat(
-        abi_decode(
-            abi_encode(_options), (Bytes[MAX_OPTIONS_TOTAL_SIZE - MAX_OPTION_SINGLE_SIZE - 4])
-        ),  # -4 for header
+        convert(_options, Bytes[MAX_OPTIONS_TOTAL_SIZE - MAX_OPTION_SINGLE_SIZE - 4]), # downcast Bytes size
         convert(EXECUTOR_WORKER_ID, bytes1),
         convert(convert(len(_option) + 1, uint16), bytes2),  # +1 for optionType
         convert(_optionType, bytes1),

--- a/tests/unitary/test_options_builder_safe_cast.py
+++ b/tests/unitary/test_options_builder_safe_cast.py
@@ -1,0 +1,67 @@
+"""Test safe casting in OptionsBuilder"""
+
+import pytest
+import boa
+
+
+def test_safe_cast_in_executor_option():
+    """Test that addExecutorOption uses safe convert() instead of abi_decode/encode"""
+    # Load the OptionsBuilder contract and verify it uses convert()
+    options_builder_code = open("contracts/oapp_vyper/OptionsBuilder.vy", "r").read()
+    
+    # Check that convert() is used consistently in both functions
+    add_executor_section = []
+    add_dvn_section = []
+    in_executor = False
+    in_dvn = False
+    
+    for line in options_builder_code.split('\n'):
+        if 'def addExecutorOption' in line:
+            in_executor = True
+            in_dvn = False
+        elif 'def addDVNOption' in line:
+            in_dvn = True
+            in_executor = False
+        elif '@internal' in line or '@external' in line:
+            in_executor = False
+            in_dvn = False
+            
+        if in_executor:
+            add_executor_section.append(line)
+        if in_dvn:
+            add_dvn_section.append(line)
+    
+    # Check that abi_decode/encode pattern is NOT used in addExecutorOption
+    executor_text = '\n'.join(add_executor_section)
+    assert 'abi_decode' not in executor_text, "addExecutorOption should not use abi_decode"
+    assert 'abi_encode' not in executor_text, "addExecutorOption should not use abi_encode"
+    
+    # Check that convert() IS used for downcasting
+    assert 'convert(_options, Bytes[' in executor_text, "addExecutorOption should use convert() for downcasting"
+    
+    # Verify both functions use the same pattern
+    dvn_text = '\n'.join(add_dvn_section)
+    assert 'convert(_options, Bytes[' in dvn_text, "addDVNOption uses convert() for downcasting"
+
+
+def test_executor_option_functionality():
+    """Test that the fixed addExecutorOption works correctly"""
+    options_builder = boa.load("contracts/oapp_vyper/OptionsBuilder.vy")
+    
+    # Test adding executor option
+    initial_options = options_builder.internal.newOptions()
+    
+    # Add an executor lzReceive option
+    gas_limit = 200000
+    msg_value = 0
+    updated_options = options_builder.internal.addExecutorLzReceiveOption(initial_options, gas_limit, msg_value)
+    
+    # Verify the option was added correctly
+    assert len(updated_options) > len(initial_options)
+    
+    # Test with multiple options to ensure downcasting works
+    second_update = options_builder.internal.addExecutorLzReceiveOption(updated_options, gas_limit * 2, msg_value)
+    assert len(second_update) > len(updated_options)
+    
+    # Test that size limits are enforced
+    # This would require creating a very large option, which is complex to test here


### PR DESCRIPTION
## Summary
This PR fixes the unsafe cast issue in OptionsBuilder.vy (INFO_unsafe_cast_could_be_safe) by using Vyper's `convert()` function instead of the `abi_decode(abi_encode(...))` pattern.

## Problem
The `addExecutorOption` function used an inefficient and potentially unsafe pattern for downcasting:
```vyper
abi_decode(abi_encode(_options), (Bytes[MAX_OPTIONS_TOTAL_SIZE - MAX_OPTION_SINGLE_SIZE - 4]))
```

## Solution
Replaced with Vyper's built-in `convert()` function, matching the pattern already used in `addDVNOption`:
```vyper
convert(_options, Bytes[MAX_OPTIONS_TOTAL_SIZE - MAX_OPTION_SINGLE_SIZE - 4])
```

## Benefits
- **Safety**: `convert()` includes built-in overflow protection
- **Efficiency**: Direct conversion is more gas-efficient than encode/decode
- **Consistency**: Now matches the pattern used in `addDVNOption`
- **Clarity**: Code intent is clearer with explicit conversion

## Testing
- Added tests to verify the unsafe pattern is not used
- Verified the fixed code works correctly
- All existing OptionsBuilder tests still pass

## References
- Audit issue: INFO_unsafe_cast_could_be_safe
- The same file's `addDVNOption` function already used the correct pattern